### PR TITLE
Update Swift.gitignore for Xcode 14.3.1

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -4,6 +4,7 @@
 
 ## User settings
 xcuserdata/
+project.xcworkspace/
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

In last v Xcode starts create new userdata files and `xcshareddata` it becomes insufficient

If this is a new template:

 - **Link to application or project’s homepage**: [my repo with new template](https://github.com/CT4TuEI3/LeetCodeSwift)
